### PR TITLE
[feat] Include latest past trip in timetable

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2,9 +2,12 @@
 @tailwind components;
 @tailwind utilities;
 
-
 @layer base {
     html {
-      font-family: "Overpass", system-ui, sans-serif;
+        font-family: "Overpass", system-ui, sans-serif;
     }
-  }
+}
+
+.departed {
+    @apply opacity-40;
+}

--- a/lib/gotrans/timetable_test.go
+++ b/lib/gotrans/timetable_test.go
@@ -1,0 +1,38 @@
+package gotrans
+
+import (
+	"testing"
+	"time"
+)
+
+func TestFilterTrips(t *testing.T) {
+	trips := Trips{
+		{OrderTime: "2025-09-03T09:00:00", TransitType: TransitTypes.Rail, Transfers: 0},
+		{OrderTime: "2025-09-03T12:00:00", TransitType: TransitTypes.Rail, Transfers: 0},
+		{OrderTime: "2025-09-03T15:00:00", TransitType: TransitTypes.Rail, Transfers: 0},
+		{OrderTime: "2025-09-03T18:00:00", TransitType: TransitTypes.Bus, Transfers: 0},
+		{OrderTime: "2025-09-03T19:00:00", TransitType: TransitTypes.Rail, Transfers: 1},
+	}
+
+	now := time.Date(2025, 9, 3, 13, 0, 0, 0, time.Local)
+
+	got, err := FilterTrips(trips, now)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := Trips{
+		{OrderTime: "2025-09-03T12:00:00", TransitType: TransitTypes.Rail, Transfers: 0},
+		{OrderTime: "2025-09-03T15:00:00", TransitType: TransitTypes.Rail, Transfers: 0},
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("expected %d trips, got %d", len(want), len(got))
+	}
+
+	for i := range want {
+		if got[i].OrderTime != want[i].OrderTime {
+			t.Errorf("trip %d: expected %s, got %s", i, want[i].OrderTime, got[i].OrderTime)
+		}
+	}
+}

--- a/lib/gotrans/types.go
+++ b/lib/gotrans/types.go
@@ -154,3 +154,9 @@ func (ts *Trips) Map(fn func(Trip) Trip) {
 		(*ts)[i] = fn(t)
 	}
 }
+
+func (ts *Trips) Sort() {
+	sort.Slice(*ts, func(i int, j int) bool {
+		return (*ts)[i].OrderTime < (*ts)[j].OrderTime
+	})
+}

--- a/views/index.html
+++ b/views/index.html
@@ -38,28 +38,30 @@
             </div>
             </div>
         </form>
-    
+
 
         <div class="fixed bottom-6 left-4 z-10 sm:bottom-8 sm:left-auto sm:right-6 lg:bottom-10 lg:right-8 flex gap-2">
             {{ template "otherway" . }}
             {{ template "dateToggle" }}
         </div>
-    
+
         <section class="mt-4 sm:mt-6 md:mt-8">
             {{ template "timetable" . }}
         </section>
     </main>
-    
+
     {{ template "footer" . }}
 
     <script>
         let interval;
-        
+
         function updateTimeToDepart() {
             const allTimeLefts = Array.from(document.querySelectorAll('.timeToDepart'));
             if (allTimeLefts.length) {
                 const now = Date.now();
-                const end = new Date(allTimeLefts[0].dataset.zeroTime).getTime();
+                // the zero-th trip is allowed to be in the past
+                // but yeah let's bail if the second one is also in the past
+                const end = new Date(allTimeLefts[1].dataset.zeroTime).getTime();
                 if (end - now < 0) {
                     return
                 }
@@ -70,10 +72,32 @@
             allTimeLefts.forEach((el) => {
                 const now = Date.now();
                 const end = new Date(el.dataset.zeroTime).getTime();
-                const min = Math.floor((end - now) / 1000 / 60);
-                const hrs = Math.floor(min / 60);
-                el.innerText = `(${hrs > 0 ? hrs + "h" : ""  }${min - (hrs * 60)}m)`;
+                const isPast = end - now < 0;
+                if (isPast) {
+                  el.innerText = `(departed)`;
+                  el.classList.remove('animate-pulse');
+                  const listEl = getParentListItem(el);
+                  if (listEl) {
+                    listEl.classList.add('departed');
+                  }
+                } else {
+                  const min = Math.floor((end - now) / 1000 / 60);
+                  const hrs = Math.floor(min / 60);
+                  el.innerText = `(${hrs > 0 ? hrs + "h" : ""  }${min - (hrs * 60)}m)`;
+                }
             })
+        }
+
+        function getParentListItem(el) {
+          let parent = el.parentNode;
+          while (parent) {
+            if (parent.tagName === 'LI'){
+              return parent;
+            } else {
+              parent = parent.parentNode;
+            }
+          }
+          return null;
         }
 
         function toggleDatePicker() {
@@ -83,14 +107,14 @@
             dateToggle.classList.toggle('bg-gray-600');
             dateToggle.classList.toggle('bg-green-600');
         }
-        
+
         function toDateOnly(date) {
             const y = date.getFullYear();
             const m = String(date.getMonth() + 1).padStart(2, "0");
             const d = String(date.getDate()).padStart(2, "0");
             return [y, m, d].join("-");
         }
-        
+
         function handleDatePickerDisabled() {
             const t = document.getElementById("renderedDate");
             const m = document.getElementById("month");
@@ -100,12 +124,12 @@
             const selected = `${y.value}-${m.value}-${d.value}`
             btn.disabled = t.value === selected || selected < toDateOnly(new Date())
         }
-        
+
         document.addEventListener("DOMContentLoaded", (event) => {
             updateTimeToDepart();
             handleDatePickerDisabled();
             interval = setInterval(updateTimeToDepart, 1000 * 5);
-            
+
             document.body.addEventListener("htmx:beforeSwap", (evt) => {
                 if (evt.detail.xhr.status === 422) {
                     evt.detail.shouldSwap = true;


### PR DESCRIPTION
what the title says.

Often I'm sitting on the train that's just left and I want to know when it'll arrive at its destination. If you refresh the page, or are only pulling it up once you're leaving, previously we'd have filtered that trip out.

![Screenshot 2025-09-03 at 11 07 21 PM](https://github.com/user-attachments/assets/518a1bba-3a22-4810-a0d7-29f84847845d)
